### PR TITLE
Support for AAD B2C

### DIFF
--- a/BlazorServerSample/Startup.cs
+++ b/BlazorServerSample/Startup.cs
@@ -35,6 +35,7 @@ namespace BlazorServerSample
                     var config = root.GetSection("app");
                     o.ClientId = config.GetValue<string>("clientId");
                     o.TenantId = config.GetValue<string>("tenantId");
+                    o.Authority = config.GetValue<string>("authority");
 
                     o.DefaultScopes = new string[] { "openid", "profile" };
                     o.PostLogoutUrl = "/loggedout";

--- a/Blazorade.Msal/Configuration/BlazoradeMsalOptions.cs
+++ b/Blazorade.Msal/Configuration/BlazoradeMsalOptions.cs
@@ -40,6 +40,28 @@ namespace Blazorade.Msal.Configuration
         public string TenantId { get; set; }
 
         /// <summary>
+        /// The full authority URI representing the Azure AD tenant that will take care of authenticating your users. If this
+        /// property is set, <see cref="TenantId"/> is ignored.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The <c>Authority</c> property allows you to use both Azure AD and Azure AD B2C. Depending on which directory
+        /// you are using, the value is constructed a bit differently.
+        /// </para>
+        /// <list type="bullet">
+        /// <item>
+        /// <term>Azure AD</term>
+        /// <description>https://login.microsoftonline.com/{tenant-name}.onmicrosoft.com</description>
+        /// </item>
+        /// <item>
+        /// <term>Azure AD B2C</term>
+        /// <description>https://{tenant-name}.b2clogin.com/{tenant-name}.onmicrosoft.com/{policy-name}</description>
+        /// </item>
+        /// </list>
+        /// </remarks>
+        public string Authority { get; set; }
+
+        /// <summary>
         /// The MSAL Browser version to use.
         /// </summary>
         /// <remarks>
@@ -95,5 +117,13 @@ namespace Blazorade.Msal.Configuration
         /// </remarks>
         public TokenCacheScope TokenCacheScope { get; set; }
 
+
+
+        internal string GetAuthority()
+        {
+            return this.Authority?.Length > 0
+                ? this.Authority
+                : $"https://login.microsoftonline.com/{ this.TenantId ?? "common" }";
+        }
     }
 }

--- a/Blazorade.Msal/Security/AuthenticationResult.cs
+++ b/Blazorade.Msal/Security/AuthenticationResult.cs
@@ -29,7 +29,7 @@ namespace Blazorade.Msal.Security
 
         public List<string> Scopes { get; set; }
 
-        public DateTimeOffset ExpiresOn { get; set; }
+        public DateTimeOffset? ExpiresOn { get; set; }
 
         public Account Account { get; set; }
 

--- a/Blazorade.Msal/Services/BlazoradeMsalService.cs
+++ b/Blazorade.Msal/Services/BlazoradeMsalService.cs
@@ -357,7 +357,7 @@ namespace Blazorade.Msal.Services
             var auth = new Dictionary<string, object>
             {
                 { "clientId", this.Options.ClientId },
-                { "authority", $"https://login.microsoftonline.com/{ this.Options.TenantId ?? "common" }" },
+                { "authority", this.Options.GetAuthority() },
                 { "navigateToLoginRequestUrl", navigateToLoginRequestUrl }
             };
 

--- a/SharedComponentsSample/TokenView.razor
+++ b/SharedComponentsSample/TokenView.razor
@@ -75,7 +75,7 @@
         {
             if (null != this.token)
             {
-                this.loginHint = this.token.IdTokenClaims["preferred_username"]?.ToString();
+                this.loginHint = this.token.Account?.UserName;
                 this.scopeString = string.Join(',', this.token.Scopes);
             }
             else
@@ -123,8 +123,21 @@
         <li>Authority: @this.token.Authority</li>
         <li>Expires On: @this.token.ExpiresOn</li>
         <li>Scopes: @string.Join(", ", this.token.Scopes?.ToArray() ?? new string[0])</li>
-        <li>Access Token: @this.token.AccessToken?.Length chars [<a href="https://jwt.ms/#access_token=@this.token.AccessToken" target="access-token">view</a>]</li>
-        <li>Id Token: @this.token.IdToken?.Length chars [<a href="https://jwt.ms/#id_token=@this.token.IdToken" target="id-token">view</a>]</li>
+        <li>
+            Access Token: @this.token.AccessToken?.Length chars
+            @if(this.token.AccessToken?.Length > 0)
+            {
+                <span>[<a href="https://jwt.ms/#access_token=@this.token.AccessToken" target="access-token">view</a>]</span>
+            }
+            
+        </li>
+        <li>
+            Id Token: @this.token.IdToken?.Length chars
+            @if(this.token.IdToken?.Length > 0)
+            {
+                <span>[<a href="https://jwt.ms/#id_token=@this.token.IdToken" target="id-token">view</a>]</span>
+            }
+        </li>
     </ul>
 }
 


### PR DESCRIPTION
Addes support for Azure AD B2C by adding the `Authority` configuration option. This will most likely also add support for any IdP that supports the same authentication flows.

Closes #1