### PR TITLE
Changed methods BlazoradeMsalService to virtual

### DIFF
--- a/Blazorade.Msal/Services/BlazoradeMsalService.cs
+++ b/Blazorade.Msal/Services/BlazoradeMsalService.cs
@@ -81,7 +81,7 @@ namespace Blazorade.Msal.Services
         /// If that failes, then the interactive option is used using the <see cref="AcquireTokenInteractiveAsync"/> method.
         /// </remarks>
         /// <param name="request">Defines how to request for a token.</param>
-        public async Task<AuthenticationResult> AcquireTokenAsync(TokenAcquisitionRequest request)
+        public virtual async Task<AuthenticationResult> AcquireTokenAsync(TokenAcquisitionRequest request)
         {
             AuthenticationResult result = null;
 
@@ -133,7 +133,7 @@ namespace Blazorade.Msal.Services
         /// a popup dialog, or by redirecting the user to the login.
         /// </summary>
         /// <param name="request">Defines how to request for a token.</param>
-        public async Task<AuthenticationResult> AcquireTokenInteractiveAsync(TokenAcquisitionRequest request)
+        public virtual async Task<AuthenticationResult> AcquireTokenInteractiveAsync(TokenAcquisitionRequest request)
         {
             if (this.Options.InteractiveLoginMode == InteractiveLoginMode.Popup)
             {
@@ -172,7 +172,7 @@ namespace Blazorade.Msal.Services
         /// Acquires a token with a popup dialog.
         /// </summary>
         /// <param name="request">Defines how to request for a token.</param>
-        public async Task<AuthenticationResult> AcquireTokenPopupAsync(TokenAcquisitionRequest request)
+        public virtual async Task<AuthenticationResult> AcquireTokenPopupAsync(TokenAcquisitionRequest request)
         {
             if (null == request) throw new ArgumentNullException(nameof(request));
 
@@ -218,7 +218,7 @@ namespace Blazorade.Msal.Services
         /// Acquires a token by redirecting the user to the identity provider.
         /// </summary>
         /// <param name="request">Defines how to request for a token.</param>
-        public async Task AcquireTokenRedirectAsync(TokenAcquisitionRequest request)
+        public virtual async Task AcquireTokenRedirectAsync(TokenAcquisitionRequest request)
         {
             var module = await this.GetBlazoradeModuleAsync();
             var data = this.CreateMsalData(loginHint: request?.LoginHint, scopes: request?.Scopes, prompt: request?.Prompt);
@@ -265,7 +265,7 @@ namespace Blazorade.Msal.Services
         /// Acquires a token silently without user interaction.
         /// </summary>
         /// <param name="request">Defines how to request for a token.</param>
-        public async Task<AuthenticationResult> AcquireTokenSilentAsync(TokenAcquisitionRequest request)
+        public virtual async Task<AuthenticationResult> AcquireTokenSilentAsync(TokenAcquisitionRequest request)
         {
             AuthenticationResult result = null;
             var module = await this.GetBlazoradeModuleAsync();
@@ -294,7 +294,7 @@ namespace Blazorade.Msal.Services
         /// <summary>
         /// Returns the default login hint for the current user. The default login hint is the login hint that was previously used to acquire a token.
         /// </summary>
-        public async Task<string> GetDefaultLoginHintAsync()
+        public virtual async Task<string> GetDefaultLoginHintAsync()
         {
             var module = await this.GetBlazoradeModuleAsync();
             var data = this.CreateMsalData();
@@ -316,7 +316,7 @@ namespace Blazorade.Msal.Services
         /// Returns <c>null</c> if the current request is not a redirect back from the identity provider.
         /// </remarks>
         /// <exception cref="FailureCallbackException">The exception that is thrown if the current request is a redirect back from login, but the redirect specifies an error with the login.</exception>
-        public async Task<AuthenticationResult> HandleRedirectPromiseAsync()
+        public virtual async Task<AuthenticationResult> HandleRedirectPromiseAsync()
         {
             var module = await this.GetBlazoradeModuleAsync();
             var data = this.CreateMsalData(navigateToLoginRequestUrl: false);
@@ -332,7 +332,7 @@ namespace Blazorade.Msal.Services
         /// <summary>
         /// Performs a logout of the current user.
         /// </summary>
-        public async Task LogoutAsync()
+        public virtual async Task LogoutAsync()
         {
             var module = await this.GetBlazoradeModuleAsync();
             var data = this.CreateMsalData();


### PR DESCRIPTION
Changed most of the methods in `BlazoradeMsalService` to virtual in order to:
- Better support customization
- Enable testing through mocking

The methods that are not virtual are methods that only forward the call to another overloaded virtual method.