### PR TITLE
Return the access token as claims

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -351,3 +351,6 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+# rider
+.idea

--- a/Blazorade-MSAL.sln
+++ b/Blazorade-MSAL.sln
@@ -27,6 +27,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SharedComponentsSample", "S
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GraphClient", "GraphClient\GraphClient.csproj", "{B70A430C-BDAD-4B20-A435-9C9A7F4C8207}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Blazorade.Msal.UnitTests", "Blazorade.Msal.UnitTests\Blazorade.Msal.UnitTests.csproj", "{DAA80952-59C1-485A-90D5-58489434D6A3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -109,6 +111,18 @@ Global
 		{B70A430C-BDAD-4B20-A435-9C9A7F4C8207}.Release|x64.Build.0 = Release|Any CPU
 		{B70A430C-BDAD-4B20-A435-9C9A7F4C8207}.Release|x86.ActiveCfg = Release|Any CPU
 		{B70A430C-BDAD-4B20-A435-9C9A7F4C8207}.Release|x86.Build.0 = Release|Any CPU
+		{DAA80952-59C1-485A-90D5-58489434D6A3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DAA80952-59C1-485A-90D5-58489434D6A3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DAA80952-59C1-485A-90D5-58489434D6A3}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{DAA80952-59C1-485A-90D5-58489434D6A3}.Debug|x64.Build.0 = Debug|Any CPU
+		{DAA80952-59C1-485A-90D5-58489434D6A3}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{DAA80952-59C1-485A-90D5-58489434D6A3}.Debug|x86.Build.0 = Debug|Any CPU
+		{DAA80952-59C1-485A-90D5-58489434D6A3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DAA80952-59C1-485A-90D5-58489434D6A3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DAA80952-59C1-485A-90D5-58489434D6A3}.Release|x64.ActiveCfg = Release|Any CPU
+		{DAA80952-59C1-485A-90D5-58489434D6A3}.Release|x64.Build.0 = Release|Any CPU
+		{DAA80952-59C1-485A-90D5-58489434D6A3}.Release|x86.ActiveCfg = Release|Any CPU
+		{DAA80952-59C1-485A-90D5-58489434D6A3}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -119,6 +133,7 @@ Global
 		{79286AAB-E3AF-4647-8EA6-B680DEE68DB6} = {27D5BEFB-F2D9-4A84-A61F-E2ADA4F1B6E9}
 		{8616164C-935F-4118-848C-4592FDA21F9D} = {27D5BEFB-F2D9-4A84-A61F-E2ADA4F1B6E9}
 		{B70A430C-BDAD-4B20-A435-9C9A7F4C8207} = {27D5BEFB-F2D9-4A84-A61F-E2ADA4F1B6E9}
+		{DAA80952-59C1-485A-90D5-58489434D6A3} = {DFBDDB47-E181-4F5F-9292-84F6B869D856}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7A02B975-9E79-4692-8B2F-B5B4063C67FF}

--- a/Blazorade.Msal.UnitTests/AuthenticationResultTests.cs
+++ b/Blazorade.Msal.UnitTests/AuthenticationResultTests.cs
@@ -1,0 +1,54 @@
+﻿using Blazorade.Msal.Security;
+using Shouldly;
+using Xunit;
+
+namespace Blazorade.Msal.UnitTests;
+
+public class AuthenticationResultTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("ciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2Njg2MTM0MjAsImV4cCI6MTcwMDE0OTQyMCwiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsIkdpdmVuTmFtZSI6IkpvaG5ueSIsIlN1cm5hbWUiOiJSb2NrZXQiLCJFbWFpbCI6Impyb2NrZXRAZXhhbXBsZS5jb20iLCJyb2xlcyI6Ik1hbmFnZXIifQ.Vgs8ZRdukLMr2u-AmhxNR")]
+    public void Should_return_accesstoken_as_empty_claims_list_on_invalid_token(string? jwt)
+    {
+        var authResult = new AuthenticationResult
+        {
+            AccessToken = jwt
+        };
+        
+        authResult.AccessTokenClaims.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Should_return_accesstoken_as_claims()
+    {
+        // http://jwtbuilder.jamiekurtz.com/
+        // {
+        //     "iss": "Online JWT Builder",
+        //     "iat": 1668613420,
+        //     "exp": 1700149420,
+        //     "aud": "www.example.com",
+        //     "sub": "jrocket@example.com",
+        //     "GivenName": "Johnny",
+        //     "Surname": "Rocket",
+        //     "Email": "jrocket@example.com",
+        //     "roles": [
+        //     "Manager",
+        //     "Project Administrator"
+        //      ]
+        // }
+        
+        const string accessTokenJwt =
+            @"eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2Njg2MTM0MjAsImV4cCI6MTcwMDE0OTQyMCwiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsIkdpdmVuTmFtZSI6IkpvaG5ueSIsIlN1cm5hbWUiOiJSb2NrZXQiLCJFbWFpbCI6Impyb2NrZXRAZXhhbXBsZS5jb20iLCJyb2xlcyI6Ik1hbmFnZXIifQ.Vgs8ZRdukLMr2u-AmhxNROvxiv7T1HHltv9EWFr77H0";
+
+        var authResult = new AuthenticationResult
+        {
+            AccessToken = accessTokenJwt
+        };
+        
+        authResult.AccessTokenClaims.ShouldNotBeEmpty();
+        authResult.AccessTokenClaims.Count().ShouldBe(9);
+        authResult.AccessTokenClaims.First(c => c.Type == "Email").Value.ShouldBe("jrocket@example.com");
+    }
+}

--- a/Blazorade.Msal.UnitTests/Blazorade.Msal.UnitTests.csproj
+++ b/Blazorade.Msal.UnitTests/Blazorade.Msal.UnitTests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+      <PackageReference Include="Shouldly" Version="4.1.0" />
+      <PackageReference Include="xunit" Version="2.4.2" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Blazorade.Msal\Blazorade.Msal.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/Blazorade.Msal/Blazorade.Msal.csproj
+++ b/Blazorade.Msal/Blazorade.Msal.csproj
@@ -36,6 +36,7 @@
   <ItemGroup>
     <PackageReference Include="Blazorade.Core" Version="3.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="6.0.2" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.25.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Blazorade.Msal/Security/AuthenticationResult.cs
+++ b/Blazorade.Msal/Security/AuthenticationResult.cs
@@ -1,7 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
+using System.Security.Claims;
 using System.Text;
+using System.Text.Json;
 using System.Threading.Tasks;
 
 namespace Blazorade.Msal.Security
@@ -25,6 +28,9 @@ namespace Blazorade.Msal.Security
 
         public Dictionary<string, object> IdTokenClaims { get; set; }
 
+        public IEnumerable<Claim> AccessTokenClaims 
+            => ReadJwtToken(AccessToken);
+
         public string AccessToken { get; set; }
 
         public List<string> Scopes { get; set; }
@@ -35,5 +41,21 @@ namespace Blazorade.Msal.Security
 
         public bool FromCache { get; set; }
 
+        private IEnumerable<Claim> ReadJwtToken(string jwt)
+        {
+            if (string.IsNullOrEmpty(jwt))
+            {
+                return Enumerable.Empty<Claim>();
+            }
+
+            try
+            {
+                return new JwtSecurityTokenHandler().ReadJwtToken(AccessToken).Claims;
+            }
+            catch (Exception)
+            {
+                return Enumerable.Empty<Claim>();
+            }
+        }
     }
 }


### PR DESCRIPTION
When you request a access token based on scope against Azure AD the roles connected to your account is in the access token. Return the access token as claims will make it easier to check the roles in your blazor app.